### PR TITLE
Adapted to non-standard header usage.

### DIFF
--- a/source/Connection.ts
+++ b/source/Connection.ts
@@ -14,9 +14,9 @@ export class Connection {
 			...init,
 			headers: {
 				...init.headers,
-				"content-type": "application/json; charset=utf-8",
-				authorization: "CertiTrade " + this.userID + ":" + crypto.createHmac("sha256", this.userKey).update((init.method || "GET") + url + date + (init.body || "")).digest("hex"),
-				date,
+				"Content-Type": "application/json; charset=utf-8",
+				Authorization: "CertiTrade " + this.userID + ":" + crypto.createHmac("sha256", this.userKey).update((init.method || "GET") + url + date + (init.body || "")).digest("hex"),
+				Date: date,
 			},
 		}
 		console.log("fetch " + url)


### PR DESCRIPTION
Card2 does not handle headers case insensitive as required by the [standard](https://tools.ietf.org/html/rfc7230#section-3.2).